### PR TITLE
Do not keep resolv.conf

### DIFF
--- a/Scripts/Arch/cleanup.sh
+++ b/Scripts/Arch/cleanup.sh
@@ -39,7 +39,6 @@ find "$BASEPATH"/usr/share -mindepth 1 -maxdepth 1 \
 
 # rm everything in /etc except /etc/alternatives and ld stuff
 find "$BASEPATH"/etc -mindepth 1 -maxdepth 1 \
-    \! -name 'resolv.conf' -a \
     \! -name 'ld.so*' -a \
     \! -name OpenCL \
     -exec rm -rf {} \;


### PR DESCRIPTION
DO NOT MERGE YET!
This is just a reminder.

I guess we should be able to remove the resolv.conf with one of the next muvm releases, when e.g. this is included:
- https://github.com/AsahiLinux/muvm/pull/111

Also see:
- https://github.com/AsahiLinux/muvm/pull/110
- https://github.com/AsahiLinux/muvm/pull/64
- https://github.com/AsahiLinux/muvm/pull/53